### PR TITLE
fix: mouse moves back after moving away

### DIFF
--- a/jiggler.py
+++ b/jiggler.py
@@ -77,12 +77,14 @@ def move_mouse(seconds, pixels):
     """
     this = current_thread()
     this.alive = True
+    flip = 1;
     while this.alive:
         sleep(seconds)
         if not this.alive:
             break
 
-        mouse.move(pixels, pixels)
+        mouse.move(pixels * flip, pixels * flip)
+        flip = flip * -1
         print("{}\t[move_mouse]\tMoved mouse to".format(time.ctime(), mouse.position))
 
 


### PR DESCRIPTION
The way the script works the mouse keeps moving in one direction until it gets stuck in the corner of the screen.

I made a small change so that after the mouse move some pixels, the next move will be in the reverse direction making the mouse come back to the original place.

This makes the mouse move back and forward around the same space.