### PR TITLE
Add optional --oscillate flag to move mouse back and forth 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Options:
 -p, --pixels INTEGER            Number of pixels the mouse should move.
                                 Default is 1
 
+-o, --oscillate                 Move mouse back and forth rather than
+                                unidirectionally.
+
 -m, --mode [m|k|mk|ks|ms|mks]   Available options: m, k, mk, ks, ms, mks;
                                 default is mks.
                                 This is the action that execites when the

--- a/jiggler.py
+++ b/jiggler.py
@@ -1,3 +1,4 @@
+from itertools import cycle
 import os
 import platform
 import time
@@ -68,22 +69,25 @@ def switch_screen(seconds, tabs, key):
             )
 
 
-def move_mouse(seconds, pixels):
+def move_mouse(seconds, pixels, oscillate=False):
     """Moves mouse every x seconds
 
     Args:
         seconds (int): Seconds to wait between consecutive move mouse actions
-        pixels ([type]): Number of pixels to move mouse
+        pixels (int): Number of pixels to move mouse
+        oscillate (bool, optional): Move mouse back and forth (default False)
     """
     this = current_thread()
     this.alive = True
+    sign = cycle((-1, 1))
     while this.alive:
         sleep(seconds)
         if not this.alive:
             break
-
+        if oscillate:
+            pixels *= next(sign)
         mouse.move(pixels, pixels)
-        print("{}\t[move_mouse]\tMoved mouse to".format(time.ctime(), mouse.position))
+        print(f"{time.ctime()}\t[move_mouse]\tMoved mouse to {mouse.position}")
 
 
 @click.group()

--- a/jiggler.py
+++ b/jiggler.py
@@ -113,6 +113,7 @@ def cli():
 @click.option(
     "-o",
     "--oscillate",
+    is_flag=True,
     help="Move mouse back and forth rather than unidirectionally."
 )
 @click.option(

--- a/jiggler.py
+++ b/jiggler.py
@@ -111,6 +111,11 @@ def cli():
     default=1,
 )
 @click.option(
+    "-o",
+    "--oscillate",
+    help="Move mouse back and forth rather than unidirectionally."
+)
+@click.option(
     "-m",
     "--mode",
     type=click.Choice(["m", "k", "mk", "ks", "ms", "mks"]),
@@ -129,12 +134,12 @@ def cli():
     help="Special key for switching windows",
     default=special_keys[platform.system()],
 )
-def start(seconds, pixels, mode, tabs, key):
+def start(seconds, pixels, oscillate, mode, tabs, key):
 
     try:
         threads = []
         if "m" in mode:
-            threads.append(Thread(target=move_mouse, args=(seconds, pixels)))
+            threads.append(Thread(target=move_mouse, args=(seconds, pixels, oscillate)))
 
         if "k" in mode:
             threads.append(Thread(target=key_press, args=(seconds,)))


### PR DESCRIPTION
This is a useful little tool for keeping my machine awake -- thanks for making it!

I did run into an issue though: the cursor moving unidirectionally to the bottom right was sometimes triggering my lock screen hot corner on MacOS (sorta defeated the purpose). So I added an option to move the mouse back and forth instead of always moving down and right.

I figured other people might have a similar issue, so I hope you don't mind an unsolicited PR.